### PR TITLE
Fix chat API room creation

### DIFF
--- a/system/chat/chat.v1.js
+++ b/system/chat/chat.v1.js
@@ -46,7 +46,7 @@
 
   // API backend
   async function apiListRooms(){ const r = await fetch(`${SITE().apiBase}/chat/rooms`, {cache:"no-cache"}); if(!r.ok) throw new Error("rooms "+r.status); return r.json(); }
-  async function apiCreateRoom(name){ const r = await fetch(`${SITE().apiBase}/chat/rooms`, { method:"POST", headers:{"Content-Type":"application/json"}, body: JSON.stringify({ name: sanitizeRoom(name) }) }); if(!r.ok) throw new Error("create "+r.status); return (await r.json())?.name || sanitizeRoom(name); }
+  async function apiCreateRoom(name){ const r = await fetch(`${SITE().apiBase}/chat/rooms`, { method:"POST", headers:{"Content-Type":"application/json"}, body: JSON.stringify({ room: sanitizeRoom(name) }) }); if(!r.ok) throw new Error("create "+r.status); return (await r.json())?.room || sanitizeRoom(name); }
   async function apiGetMsgs(room){ const r = await fetch(`${SITE().apiBase}/chat/rooms/${encodeURIComponent(room)}`, {cache:"no-cache"}); if(!r.ok) throw new Error("msgs "+r.status); return r.json(); }
   async function apiPostMsg(room, msg){ const r = await fetch(`${SITE().apiBase}/chat/rooms/${encodeURIComponent(room)}`, { method:"POST", headers:{"Content-Type":"application/json"}, body: JSON.stringify(msg) }); if(!r.ok) throw new Error("post "+r.status); }
 


### PR DESCRIPTION
## Summary
- Ensure chat room creation uses `room` field to match server API

## Testing
- `npm test` (fails: Missing script: "test")
- `SITE_ROOT=/workspace/iadorefrogs-site SESSION_SECURE=false node server.js` & `curl -s -b cookie.txt -X POST -H "Content-Type: application/json" -d '{"room":"testroom"}' http://127.0.0.1:3000/api/chat/rooms`

------
https://chatgpt.com/codex/tasks/task_e_689d773269f483259143c5cf5fe372ae