### PR TITLE
Refactor sanitizeRoom into utility with tests

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -5,7 +5,8 @@
   "main": "server.js",
   "type": "commonjs",
   "scripts": {
-    "start": "node server.js"
+    "start": "node server.js",
+    "test": "node --test"
   },
   "dependencies": {
     "bcryptjs": "^2.4.3",

--- a/server/server.js
+++ b/server/server.js
@@ -39,7 +39,7 @@ const writeJson = async (p, obj) => {
   await fs.writeFile(tmp, JSON.stringify(obj, null, 2));
   await fs.rename(tmp, p);
 };
-const sanitizeRoom = (name) => (name || '').toString().toLowerCase().replace(/[^a-z0-9-_]/g, '').slice(0, 64) || 'public';
+const sanitizeRoom = require('./utils/sanitizeRoom');
 const isDev = (req) => req.session?.user?.tier === 'devmode';
 const isLogged = (req) => !!req.session?.user;
 

--- a/server/test/sanitizeRoom.test.js
+++ b/server/test/sanitizeRoom.test.js
@@ -1,0 +1,21 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const sanitizeRoom = require('../utils/sanitizeRoom');
+
+test('allowed characters are preserved and lowercased', () => {
+  assert.strictEqual(sanitizeRoom('AbC-123_DEF'), 'abc-123_def');
+});
+
+test('strips disallowed characters', () => {
+  assert.strictEqual(sanitizeRoom('Hello!@# World?'), 'helloworld');
+});
+
+test('trims length to 64 characters', () => {
+  const long = 'a'.repeat(70);
+  assert.strictEqual(sanitizeRoom(long).length, 64);
+});
+
+test("falls back to 'public' on empty input", () => {
+  assert.strictEqual(sanitizeRoom(''), 'public');
+  assert.strictEqual(sanitizeRoom('???'), 'public');
+});

--- a/server/utils/sanitizeRoom.js
+++ b/server/utils/sanitizeRoom.js
@@ -1,0 +1,9 @@
+// server/utils/sanitizeRoom.js
+// Utility to sanitize chat room names.
+module.exports = function sanitizeRoom(name) {
+  return (name || '')
+    .toString()
+    .toLowerCase()
+    .replace(/[^a-z0-9-_]/g, '')
+    .slice(0, 64) || 'public';
+};


### PR DESCRIPTION
## Summary
- extract `sanitizeRoom` into reusable `utils/sanitizeRoom.js`
- cover room name sanitization with node:test
- add npm test script for the server package

## Testing
- `cd server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d7babdb2c8325b76aa33e55270710