### PR TITLE
Fix chat room API handling

### DIFF
--- a/apps/chat/chat.js
+++ b/apps/chat/chat.js
@@ -52,15 +52,16 @@
   async function apiListRooms(){
     const r = await fetch(`${SITE().apiBase}/chat/rooms`, {cache:"no-cache"});
     if (!r.ok) throw new Error("rooms "+r.status);
-    return r.json();
+    return (await r.json()).rooms;
   }
   async function apiCreateRoom(name){
     const r = await fetch(`${SITE().apiBase}/chat/rooms`, {
       method:"POST", headers:{"Content-Type":"application/json"},
-      body: JSON.stringify({ name: sanitizeRoom(name) })
+      body: JSON.stringify({ room: sanitizeRoom(name) })
     });
     if (!r.ok) throw new Error("create "+r.status);
-    return (await r.json())?.name || sanitizeRoom(name);
+    const resp = await r.json();
+    return resp.room;
   }
   async function apiGetMsgs(room){
     const r = await fetch(`${SITE().apiBase}/chat/rooms/${encodeURIComponent(room)}`, {cache:"no-cache"});

--- a/system/chat/chat.v1.js
+++ b/system/chat/chat.v1.js
@@ -45,8 +45,8 @@
   }
 
   // API backend
-  async function apiListRooms(){ const r = await fetch(`${SITE().apiBase}/chat/rooms`, {cache:"no-cache"}); if(!r.ok) throw new Error("rooms "+r.status); return r.json(); }
-  async function apiCreateRoom(name){ const r = await fetch(`${SITE().apiBase}/chat/rooms`, { method:"POST", headers:{"Content-Type":"application/json"}, body: JSON.stringify({ name: sanitizeRoom(name) }) }); if(!r.ok) throw new Error("create "+r.status); return (await r.json())?.name || sanitizeRoom(name); }
+  async function apiListRooms(){ const r = await fetch(`${SITE().apiBase}/chat/rooms`, {cache:"no-cache"}); if(!r.ok) throw new Error("rooms "+r.status); return (await r.json()).rooms; }
+  async function apiCreateRoom(name){ const r = await fetch(`${SITE().apiBase}/chat/rooms`, { method:"POST", headers:{"Content-Type":"application/json"}, body: JSON.stringify({ room: sanitizeRoom(name) }) }); if(!r.ok) throw new Error("create "+r.status); const resp = await r.json(); return resp.room; }
   async function apiGetMsgs(room){ const r = await fetch(`${SITE().apiBase}/chat/rooms/${encodeURIComponent(room)}`, {cache:"no-cache"}); if(!r.ok) throw new Error("msgs "+r.status); return r.json(); }
   async function apiPostMsg(room, msg){ const r = await fetch(`${SITE().apiBase}/chat/rooms/${encodeURIComponent(room)}`, { method:"POST", headers:{"Content-Type":"application/json"}, body: JSON.stringify(msg) }); if(!r.ok) throw new Error("post "+r.status); }
 


### PR DESCRIPTION
## Summary
- Align chat API client with server's `room` field
- Parse room list from server responses

## Testing
- `curl -s -b cookies.txt -H 'Content-Type: application/json' -d '{"room":"testrm124"}' http://127.0.0.1:3000/api/chat/rooms -w '\n'`
- `curl -s http://127.0.0.1:3000/api/chat/rooms -w '\n'`


------
https://chatgpt.com/codex/tasks/task_e_689d7ba80e008325a7119fe723847061