### PR TITLE
Remove broken start menu stylesheet reference

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>I ADORE FROGS — Desktop</title>
-  <link rel="stylesheet" href="system/startmenu/start.cs">
   <link rel="stylesheet" href="assets/css/base.css">
   <link rel="icon" type="image/png" href="assets/favicon.png">
 </head>


### PR DESCRIPTION
## Summary
- remove invalid `system/startmenu/start.cs` stylesheet reference from `index.html`

## Testing
- `npm test` (fails: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_689d7ba1d6088325bc6fb7704d2ff41a