### PR TITLE
Fix missing app icons by using relative paths

### DIFF
--- a/system/loader.v1.js
+++ b/system/loader.v1.js
@@ -33,8 +33,8 @@
   }
 
   async function openAppWindow(app) {
-  const url = app.url || (app.path || `/apps/${app.id}/layout.html`);
-  const icon = app.icon || `/assets/apps/${app.id}/icon.png`;
+  const url = app.url || (app.path || `apps/${app.id}/layout.html`);
+  const icon = app.icon || `assets/apps/${app.id}/icon.png`;
   const title = app.title || app.id;
 
   if (window.WM?.open) {
@@ -50,8 +50,7 @@
   window.open(url, '_blank', 'noopener');
 }
 
-
-  function iconPath(id, icon){ if(!icon||!icon.trim()) return `/assets/apps/${id}/icon.png`; if(icon.startsWith('/')||icon.startsWith('http')) return icon; return `/assets/apps/${id}/${icon}`; }
+  function iconPath(id, icon){ if(!icon||!icon.trim()) return `assets/apps/${id}/icon.png`; if(icon.startsWith('/')||icon.startsWith('http')) return icon; return `assets/apps/${id}/${icon}`; }
   function addIcon(desktop, app) {
   const iconEl = document.createElement('div');
   iconEl.className = 'icon';
@@ -60,7 +59,7 @@
   imgWrap.className = 'icon-img';
   const img = document.createElement('img');
   img.className = 'desk-icon-img';
-  img.src = app.icon || `/assets/apps/${app.id}/icon.png`;
+  img.src = app.icon || `assets/apps/${app.id}/icon.png`;
   imgWrap.appendChild(img);
 
   const label = document.createElement('div');
@@ -80,11 +79,11 @@
 
 
   async function buildDesktop(desktop, me){
-    let ids=[]; try{ ids=await getJSON('/apps/apps.json'); }catch(e){ console.warn('apps.json failed',e); }
+    let ids=[]; try{ ids=await getJSON('apps/apps.json'); }catch(e){ console.warn('apps.json failed',e); }
     if(!Array.isArray(ids)) ids=[];
     for(const id of ids){
       try{
-        const meta=await getJSON(`/apps/${id}/app.json`);
+        const meta=await getJSON(`apps/${id}/app.json`);
         addIcon(desktop,{ id, title:meta.title||id, icon:iconPath(id,meta.icon), x:meta.x,y:meta.y,w:meta.w,h:meta.h });
       }catch(e){ console.warn(`app ${id} meta failed`,e); }
     }
@@ -102,11 +101,11 @@
 
   const boot=async()=>{
     const {desktop}=ensureChrome();
-    let site={apiBase:'/api',devMode:false,wallpaper:'/assets/wallpapers/frogs.jpg'};
-    try{ site={...site,...(await getJSON('/config/site.json'))}; }catch{}
+    let site={apiBase:'/api',devMode:false,wallpaper:'assets/wallpapers/frogs.jpg'};
+    try{ site={...site,...(await getJSON('config/site.json'))}; }catch{}
     const API=site.apiBase||'/api'; window.API=API; window.API_BASE=API; window.siteConfig=site;
     try{
-      const wp=site.wallpaper||'/assets/wallpapers/frogs.jpg';
+      const wp=site.wallpaper||'assets/wallpapers/frogs.jpg';
       Object.assign(document.body.style,{backgroundImage:`url('${wp}')`,backgroundSize:'cover',backgroundPosition:'center',backgroundRepeat:'no-repeat'});
     }catch{}
     let me=guest; try{ me=await getJSON(`${API}/me`);}catch{} window.currentUser=me;

--- a/system/startmenu/start.v1.js
+++ b/system/startmenu/start.v1.js
@@ -33,8 +33,8 @@
         window.WM?.open({
           id: 'auth',
           title: 'Account',
-          icon: '/assets/apps/auth/icon.png',
-          url: '/apps/auth/layout.html',
+          icon: 'assets/apps/auth/icon.png',
+          url: 'apps/auth/layout.html',
           w: 420, h: 360, x: 80, y: 80
         });
       });
@@ -45,8 +45,8 @@
       window.WM?.open({
         id: 'customize',
         title: 'Customize',
-        icon: '/assets/apps/customize/icon.png',
-        url: '/apps/customize/layout.html',
+        icon: 'assets/apps/customize/icon.png',
+        url: 'apps/customize/layout.html',
         w: 520, h: 420, x: 120, y: 110
       });
     });
@@ -54,8 +54,8 @@
       window.WM?.open({
         id: 'bug',
         title: 'Bug Report',
-        icon: '/assets/apps/bug/icon.png',
-        url: '/apps/bug/layout.html',
+        icon: 'assets/apps/bug/icon.png',
+        url: 'apps/bug/layout.html',
         w: 520, h: 420, x: 140, y: 130
       });
     });

--- a/system/wm.v1.js
+++ b/system/wm.v1.js
@@ -47,7 +47,7 @@
     b.className = 'taskbtn';
     const img = document.createElement('img');
     img.className = 'taskicon';
-    img.src = icon || '/assets/favicon.png';
+    img.src = icon || 'assets/favicon.png';
     const span = document.createElement('span');
     span.className = 'tasklabel';
     span.textContent = title || id;


### PR DESCRIPTION
## Summary
- load apps and icons using relative paths so desktop apps like chat appear when site is served from a subdirectory
- update start menu and window manager to use relative asset paths

## Testing
- `cd server && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d80c002608325bc677d7378fe67ce