### PR TITLE
Split auth menu and hash navigation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 system/data/
 system/chat/rooms/
+server/node_modules/

--- a/apps/auth/app.json
+++ b/apps/auth/app.json
@@ -3,5 +3,5 @@
   "icon": "/assets/apps/auth/icon.png",
   "access": "guest",
   "w": 420,
-  "h": 360
+  "h": 420
 }

--- a/apps/auth/layout.html
+++ b/apps/auth/layout.html
@@ -53,26 +53,30 @@
     // Same-origin with parent, so we can call /api directly and reload top on success
     async function fetchJSON(u, opt){ const r = await fetch(u, { credentials:'include', ...opt }); if(!r.ok) throw new Error((await r.text())||r.status); return r.json(); }
 
+    function showPaneFromHash(){
+      const hash = window.location.hash === '#create' ? '#create' : '#login';
+      const li = document.getElementById('login-pane');
+      const cr = document.getElementById('create-pane');
+      if(hash === '#create'){ li.style.display='none'; cr.style.display=''; }
+      else { li.style.display=''; cr.style.display='none'; }
+    }
+
     async function refreshMe(){
       try{
         const me = await fetchJSON('/api/me');
         const si = document.getElementById('signed-in');
-        const li = document.getElementById('login-pane');
-        const cr = document.getElementById('create-pane');
         if (me && me.username){
-          li.style.display='none';
-          cr.style.display='none';
+          document.getElementById('login-pane').style.display='none';
+          document.getElementById('create-pane').style.display='none';
           si.style.display='';
           document.getElementById('me-name').textContent = me.username + (me.tier ? ` (${me.tier})` : '');
         }else{
-          li.style.display='';
-          cr.style.display='none';
           si.style.display='none';
+          showPaneFromHash();
         }
       }catch{
-        document.getElementById('login-pane').style.display='';
-        document.getElementById('create-pane').style.display='none';
         document.getElementById('signed-in').style.display='none';
+        showPaneFromHash();
       }
     }
 
@@ -98,14 +102,8 @@
       }catch(e){ st.textContent='Account creation failed.'; }
     };
 
-    document.getElementById('show-create').onclick = ()=>{
-      document.getElementById('login-pane').style.display='none';
-      document.getElementById('create-pane').style.display='';
-    };
-    document.getElementById('show-login').onclick = ()=>{
-      document.getElementById('login-pane').style.display='';
-      document.getElementById('create-pane').style.display='none';
-    };
+    document.getElementById('show-create').onclick = ()=>{ window.location.hash = '#create'; };
+    document.getElementById('show-login').onclick = ()=>{ window.location.hash = '#login'; };
 
     document.getElementById('btn-logout').onclick = async ()=>{
       const st = document.getElementById('lo-status'); st.textContent='';
@@ -115,6 +113,8 @@
       }catch(e){ st.textContent='Logout failed.'; }
     };
 
+    window.addEventListener('hashchange', showPaneFromHash);
+    showPaneFromHash();
     refreshMe();
   </script>
 </body>

--- a/system/loader.v1.js
+++ b/system/loader.v1.js
@@ -42,7 +42,7 @@
   if (window.WM?.open) {
     window.WM.open({
       id: app.id, title, icon, url,
-      w: app.w || 640, h: app.h || 480,
+      w: app.w || 640, h: app.h || 420,
       x: app.x || 120, y: app.y || 90
     });
     return;

--- a/system/startmenu/start.v1.js
+++ b/system/startmenu/start.v1.js
@@ -29,15 +29,18 @@
         window.location.reload();
       });
     } else {
-      mkItem(menu, 'Login / Create account', () => {
-        window.WM?.open({
+      const openAuth = (hash) => {
+        const inst = window.WM?.open({
           id: 'auth',
           title: 'Account',
           icon: 'assets/apps/auth/icon.png',
-          url: 'apps/auth/layout.html',
-          w: 420, h: 360, x: 80, y: 80
+          url: `apps/auth/layout.html${hash}`,
+          w: 420, h: 420, x: 80, y: 80
         });
-      });
+        if (inst?.iframe) inst.iframe.src = `apps/auth/layout.html${hash}`;
+      };
+      mkItem(menu, 'Login', () => openAuth('#login'));
+      mkItem(menu, 'Create account', () => openAuth('#create'));
     }
 
     // Always visible utilities (open if present)

--- a/system/wm.v1.js
+++ b/system/wm.v1.js
@@ -86,7 +86,7 @@
     });
   }
 
-  function createWindow({ id, title, icon, url, w=640, h=480, x=120, y=90 }) {
+  function createWindow({ id, title, icon, url, w=640, h=420, x=120, y=90 }) {
     const win = document.createElement('div');
     win.className = 'window active-window';
     win.style.position = 'absolute';


### PR DESCRIPTION
## Summary
- Separate start menu options for Login and Create account, opening the Account window directly to each tab.
- Account layout honors URL hash for deep linking and updates the hash when switching panes.
- Default window height standardized to 420px and auth app metadata updated.
- Ignore server/node_modules/ in git.

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d871239a08325811b42dc26dfb54f