### PR TITLE
Fix login window, guest fallback, and add missing utility pages

### DIFF
--- a/apps/auth/layout.html
+++ b/apps/auth/layout.html
@@ -5,7 +5,8 @@
   <title>Account</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <style>
-    body{margin:0;font:13px Tahoma, "MS Sans Serif", Arial, sans-serif;background:#fff;color:#000}
+    html,body{height:100%}
+    body{margin:0;font:13px Tahoma, "MS Sans Serif", Arial, sans-serif;background:#fff;color:#000;display:flex;align-items:center;justify-content:center}
     .pane{padding:10px}
     .group{border:2px inset #808080; padding:10px; background:#f2f2f2; margin-bottom:10px}
     label{display:block;margin:6px 0 2px}

--- a/apps/bug/layout.html
+++ b/apps/bug/layout.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Bug Report</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <style>body{margin:0;padding:10px;font:13px Tahoma,"MS Sans Serif",Arial,sans-serif;background:#fff;color:#000}</style>
+</head>
+<body>
+  <p>Please describe any issues you encounter. This page is a placeholder.</p>
+</body>
+</html>

--- a/apps/customize/layout.html
+++ b/apps/customize/layout.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Customize</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <style>body{margin:0;padding:10px;font:13px Tahoma,"MS Sans Serif",Arial,sans-serif;background:#fff;color:#000}</style>
+</head>
+<body>
+  <p>Customization options coming soon.</p>
+</body>
+</html>

--- a/system/loader.v1.js
+++ b/system/loader.v1.js
@@ -112,7 +112,8 @@
       const wp=site.wallpaper||'assets/wallpapers/frogs.jpg';
       Object.assign(document.body.style,{backgroundImage:`url('${wp}')`,backgroundSize:'cover',backgroundPosition:'center',backgroundRepeat:'no-repeat'});
     }catch{}
-    let me=guest; try{ me=await getJSON(`${API}/me`);}catch{} window.currentUser=me;
+    let me=guest; window.currentUser=me;
+    try{ me=await getJSON(`${API}/me`); window.currentUser=me; }catch{}
     updateStatus(me);
     if(me.tier==='devmode'){ getJSON(`${API}/admin/settings`).then(s=>window.siteAdmin=s).catch(()=>{}); }
     await buildDesktop(desktop, me);

--- a/system/startmenu/start.v1.js
+++ b/system/startmenu/start.v1.js
@@ -35,7 +35,7 @@
           title: 'Account',
           icon: 'assets/apps/auth/icon.png',
           url: `apps/auth/layout.html${hash}`,
-          w: 420, h: 420, x: 80, y: 80
+          w: 420, h: 460, x: 80, y: 80
         });
         if (inst?.iframe) inst.iframe.src = `apps/auth/layout.html${hash}`;
       };
@@ -48,7 +48,7 @@
       window.WM?.open({
         id: 'customize',
         title: 'Customize',
-        icon: 'assets/apps/customize/icon.png',
+        icon: 'assets/apps/profile/icon.png',
         url: 'apps/customize/layout.html',
         w: 520, h: 420, x: 120, y: 110
       });
@@ -57,7 +57,7 @@
       window.WM?.open({
         id: 'bug',
         title: 'Bug Report',
-        icon: 'assets/apps/bug/icon.png',
+        icon: 'assets/apps/info/icon.png',
         url: 'apps/bug/layout.html',
         w: 520, h: 420, x: 140, y: 130
       });


### PR DESCRIPTION
## Summary
- Center login UI to remove scroll
- Default unauthenticated users to guest mode
- Add placeholder Customize and Bug Report apps using existing icons to avoid binary assets

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d8bccca748325846e1faa93585289