### PR TITLE
Improve login flow and show user status

### DIFF
--- a/apps/auth/app.json
+++ b/apps/auth/app.json
@@ -2,6 +2,6 @@
   "title": "Account",
   "icon": "/assets/apps/auth/icon.png",
   "access": "guest",
-  "w": 420,
-  "h": 420
+  "w": 480,
+  "h": 480
 }

--- a/apps/auth/layout.html
+++ b/apps/auth/layout.html
@@ -87,8 +87,8 @@
       const st = document.getElementById('li-status'); st.textContent='';
       if(!u||!p){ st.textContent='Enter username and password.'; return; }
       try{
-        await fetchJSON('/api/login',{ method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({username:u,password:p})});
-        window.top.location.reload();
+        await window.top.auth.login(u,p);
+        refreshMe();
       }catch(e){ st.textContent='Login failed.'; }
     };
 
@@ -99,7 +99,8 @@
       if(!u||!p){ st.textContent='Enter username and password.'; return; }
       try{
         await fetchJSON('/api/register',{ method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({username:u,password:p})});
-        window.top.location.reload();
+        await window.top.auth.login(u,p);
+        refreshMe();
       }catch(e){ st.textContent='Account creation failed.'; }
     };
 
@@ -109,8 +110,8 @@
     document.getElementById('btn-logout').onclick = async ()=>{
       const st = document.getElementById('lo-status'); st.textContent='';
       try{
-        await fetchJSON('/api/logout',{ method:'POST' });
-        window.top.location.reload();
+        await window.top.auth.logout();
+        refreshMe();
       }catch(e){ st.textContent='Logout failed.'; }
     };
 

--- a/system/loader.v1.js
+++ b/system/loader.v1.js
@@ -94,9 +94,10 @@
   function updateStatus(me){
     const el=document.getElementById('user-status');
     if(!el) return;
+    const cap = s => s ? s.charAt(0).toUpperCase()+s.slice(1) : s;
     if(me && (me.username || me.id)){
       const id = me.id ?? me.username;
-      const status = me.status ?? me.tier;
+      const status = cap(me.status ?? me.tier);
       el.textContent = status ? `${id} (${status})` : `${id}`;
     }else{
       el.textContent='Guest';

--- a/system/startmenu/start.v1.js
+++ b/system/startmenu/start.v1.js
@@ -26,7 +26,6 @@
       mkItem(menu, `Logged in as ${me.username}${me.tier ? ' ('+me.tier+')' : ''}`, () => {});
       mkItem(menu, 'Logout', async () => {
         try { await window.auth?.logout?.(); } catch {}
-        window.location.reload();
       });
     } else {
       const openAuth = (hash) => {
@@ -35,7 +34,7 @@
           title: 'Account',
           icon: 'assets/apps/auth/icon.png',
           url: `apps/auth/layout.html${hash}`,
-          w: 420, h: 460, x: 80, y: 80
+          w: 480, h: 520, x: 80, y: 80
         });
         if (inst?.iframe) inst.iframe.src = `apps/auth/layout.html${hash}`;
       };


### PR DESCRIPTION
## Summary
- Avoid full page reload on login/logout and update auth app to use window.auth
- Display capitalized role and username in taskbar status
- Enlarge Account/login window for easier use

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d9191ae988325811673f57ca93423