### PR TITLE
feat: enhance desktop customization

### DIFF
--- a/apps/auth/layout.html
+++ b/apps/auth/layout.html
@@ -6,8 +6,9 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <style>
     html,body{height:100%}
-    body{margin:0;font:13px Tahoma, "MS Sans Serif", Arial, sans-serif;background:#fff;color:#000;display:flex;align-items:center;justify-content:center}
-    .pane{padding:10px}
+    body{margin:0;font:13px Tahoma, "MS Sans Serif", Arial, sans-serif;background:#fff;color:#000;display:flex;align-items:stretch;justify-content:center}
+    .pane{padding:10px;height:100%;box-sizing:border-box;display:flex;flex-direction:column}
+    #login-pane{flex:1}
     .group{border:2px inset #808080; padding:10px; background:#f2f2f2; margin-bottom:10px}
     label{display:block;margin:6px 0 2px}
     input{width:100%; box-sizing:border-box; padding:6px; border:2px inset #808080; background:#fff}
@@ -89,6 +90,7 @@
       try{
         await window.top.auth.login(u,p);
         refreshMe();
+        window.top.WM?.close('auth');
       }catch(e){ st.textContent='Login failed.'; }
     };
 
@@ -101,6 +103,7 @@
         await fetchJSON('/api/register',{ method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify({username:u,password:p})});
         await window.top.auth.login(u,p);
         refreshMe();
+        window.top.WM?.close('auth');
       }catch(e){ st.textContent='Account creation failed.'; }
     };
 

--- a/apps/customize/layout.html
+++ b/apps/customize/layout.html
@@ -4,9 +4,69 @@
   <meta charset="utf-8">
   <title>Customize</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
-  <style>body{margin:0;padding:10px;font:13px Tahoma,"MS Sans Serif",Arial,sans-serif;background:#fff;color:#000}</style>
+  <style>
+    html,body{height:100%}
+    body{margin:0;padding:10px;font:13px Tahoma,"MS Sans Serif",Arial,sans-serif;background:#fff;color:#000;display:flex;flex-direction:column}
+    #apps{flex:1;overflow:auto}
+    .row{display:flex;align-items:center;gap:8px;margin-bottom:4px}
+    label{margin-right:10px}
+    button{background:#c0c0c0;border:2px outset #fff;padding:2px 6px;cursor:pointer}
+    button:active{border:2px inset #fff}
+    .buttons{display:flex;gap:8px;margin-top:8px}
+  </style>
 </head>
 <body>
-  <p>Customization options coming soon.</p>
+  <div id="apps"></div>
+  <div class="buttons">
+    <button id="save">Save</button>
+    <button id="cancel">Cancel</button>
+  </div>
+  <script>
+    const KEY='desktop_settings';
+    function load(){try{return JSON.parse(window.top.localStorage.getItem(KEY))||{};}catch{return{};}}
+    function save(s){try{window.top.localStorage.setItem(KEY, JSON.stringify(s));}catch{}}
+    async function init(){
+      const listEl=document.getElementById('apps');
+      const ids=await (await fetch('../apps.json')).json();
+      const settings=load();
+      const order=(settings.pinnedOrder&&settings.pinnedOrder.filter(id=>ids.includes(id)))||ids.slice();
+      ids.forEach(id=>{if(!order.includes(id)) order.push(id);});
+      order.forEach(id=>{
+        const s=settings[id]||{};
+        const row=document.createElement('div');
+        row.className='row';
+        row.dataset.id=id;
+        row.innerHTML=`<button class="up">\u25B2</button><button class="down">\u25BC</button>`+
+          `<label><input type="checkbox" class="show" ${s.show!==false?'checked':''}> Show</label>`+
+          `<label><input type="checkbox" class="pin" ${s.pinned?'checked':''}> Pin</label> ${id}`;
+        listEl.appendChild(row);
+      });
+      listEl.addEventListener('click',e=>{
+        const row=e.target.closest('.row');
+        if(!row) return;
+        if(e.target.classList.contains('up')){
+          const prev=row.previousElementSibling; if(prev) listEl.insertBefore(row,prev);
+        }
+        if(e.target.classList.contains('down')){
+          const next=row.nextElementSibling; if(next) listEl.insertBefore(next,row);
+        }
+      });
+      document.getElementById('save').onclick=()=>{
+        const s=load();
+        Array.from(listEl.children).forEach(row=>{
+          const id=row.dataset.id;
+          s[id]=s[id]||{};
+          s[id].show=row.querySelector('.show').checked;
+          s[id].pinned=row.querySelector('.pin').checked;
+        });
+        s.pinnedOrder=Array.from(listEl.children).map(r=>r.dataset.id);
+        save(s);
+        window.top.refreshDesktop?.();
+        window.top.WM?.close('customize');
+      };
+      document.getElementById('cancel').onclick=()=>{window.top.WM?.close('customize');};
+    }
+    init();
+  </script>
 </body>
 </html>

--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -35,14 +35,19 @@ body{
 
 /* Icons grid */
 #icons {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, 92px); /* up to 5 columns of fixed 92px icons */
-  gap: 18px;
-  padding: 16px;
-  max-width: calc(92px * 5 + 18px * 4);  /* limit width to 5 icons per row (≈532px) */
-  justify-content: start;               /* align icons to the left */
+  position: relative;
+  width: 100%;
+  height: 100%;
 }
-.icon{display:flex; flex-direction:column; align-items:center; gap:6px; color:#fff; cursor:default}
+.icon{
+  position: absolute;
+  display:flex;
+  flex-direction:column;
+  align-items:center;
+  gap:6px;
+  color:#fff;
+  cursor:move;
+}
 
 /* Image-only desktop icons */
 .icon-img{ width:64px; height:64px; display:grid; place-items:center; }
@@ -118,6 +123,25 @@ body{
   border-radius: 3px;
 }
 
+.quick-note{
+  position: absolute;
+  right: 10px;
+  bottom: calc(var(--taskbar-height) + var(--taskbar-band) + 40px);
+  display:flex;
+  flex-direction:column;
+  gap:4px;
+}
+.quick-note label{
+  color:#fff;
+  font-size:12px;
+  text-shadow:1px 1px 0 #000;
+}
+.quick-note input{
+  padding:4px;
+  width:200px;
+  box-sizing:border-box;
+}
+
 /* Clock inside bar, right */
 .clock{
   box-sizing: border-box;
@@ -150,16 +174,17 @@ body{
 }
 
 /* Windows */
-.window{
-  position:absolute;
-  background:var(--win);
-  border:2px solid var(--border-dark);
-  outline:1px solid var(--border-light);
-  box-shadow:6px 6px 0 var(--shadow);
-  
-  min-width:280px; max-width:min(94vw, 900px);
-  z-index:100;
-}
+  .window{
+    position:absolute;
+    background:var(--win);
+    border:2px solid var(--border-dark);
+    outline:1px solid var(--border-light);
+    box-shadow:6px 6px 0 var(--shadow);
+
+    min-width:280px; max-width:min(94vw, 900px);
+    z-index:100;
+    display:flex; flex-direction:column;
+  }
 .window.active-window{ background:var(--win-active); }
 .window .titlebar{
   background:var(--title-inactive);
@@ -184,8 +209,8 @@ body{
 }
 .window .controls .btn:hover{ filter:brightness(0.95); }
 
-.toolbar{ padding:6px; background:var(--win); border-bottom:2px outset var(--border-light) }
-.content{ padding:10px; background:#fff; border-top:2px inset var(--border-mid); max-height:62vh; overflow:auto }
+  .toolbar{ padding:6px; background:var(--win); border-bottom:2px outset var(--border-light) }
+  .content{ padding:10px; background:#fff; border-top:2px inset var(--border-mid); flex:1; overflow:auto }
 
 /* Placeholder blocks */
 .ph{display:grid; grid-template-columns:repeat(auto-fill, minmax(140px,1fr)); gap:12px}

--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
 
   <div id="taskbar" class="taskbar">
     <button id="start-button" class="start">Start</button>
+    <div id="quick-launch" class="quick"></div>
     <div id="tasks" class="tasks"></div>   <!-- NEW: task buttons live here -->
     <div class="clock"></div>
   </div>
@@ -21,6 +22,10 @@
   <div id="start-menu" class="start-menu hidden"></div>
 
   <div id="user-status" class="status-outside"></div>
+  <div id="quick-note" class="quick-note">
+    <label id="quick-note-user"></label>
+    <input id="quick-note-input" type="text" />
+  </div>
 
   <!-- ORDER MATTERS -->
   <script src="system/wm.v1.js"></script>

--- a/system/loader.v1.js
+++ b/system/loader.v1.js
@@ -13,6 +13,9 @@
   window.getJSON=(u,o)=>_fetchJSON(u,o); window.postJSON=(u,d)=>_sendJSON(u,'POST',d); window.putJSON=(u,d)=>_sendJSON(u,'PUT',d);
 
   const guest={username:null,name:'Guest',tier:'guest'};
+  const SETTINGS_KEY='desktop_settings';
+  function loadSettings(){ try{ return JSON.parse(localStorage.getItem(SETTINGS_KEY))||{}; }catch{ return {}; } }
+  function saveSettings(s){ try{ localStorage.setItem(SETTINGS_KEY, JSON.stringify(s)); }catch{} }
 
   function ensure(id,cls){let e=document.getElementById(id); if(!e){ e=document.createElement('div'); e.id=id; if(cls)e.className=cls; document.body.appendChild(e);} return e;}
   function ensureChrome(){
@@ -20,6 +23,11 @@
     const taskbar=ensure('taskbar','taskbar');
     if(!document.getElementById('start-button')){
       const b=document.createElement('button'); b.id='start-button'; b.className='start-button'; b.textContent='Start'; taskbar.appendChild(b);
+    }
+    if(!document.getElementById('quick-launch')){
+      const q=document.createElement('div'); q.id='quick-launch'; q.className='quick';
+      const tasks=document.getElementById('tasks');
+      taskbar.insertBefore(q, tasks);
     }
     if(!document.querySelector('.spacer')){ taskbar.appendChild(Object.assign(document.createElement('div'),{className:'spacer'})); }
     if(!document.querySelector('.clock')){ taskbar.appendChild(Object.assign(document.createElement('div'),{className:'clock'})); }
@@ -53,54 +61,127 @@
 }
 
   function iconPath(id, icon){ if(!icon||!icon.trim()) return `assets/apps/${id}/icon.png`; if(icon.startsWith('/')||icon.startsWith('http')) return icon; return `assets/apps/${id}/${icon}`; }
-  function addIcon(desktop, app) {
-  const iconEl = document.createElement('div');
-  iconEl.className = 'icon';
 
-  const imgWrap = document.createElement('div');
-  imgWrap.className = 'icon-img';
-  const img = document.createElement('img');
-  img.className = 'desk-icon-img';
-  img.src = app.icon || `assets/apps/${app.id}/icon.png`;
-  imgWrap.appendChild(img);
+  function addQuickIcon(quick, app){
+    if(!quick) return;
+    const btn=document.createElement('button');
+    btn.className='ql';
+    const img=document.createElement('img');
+    img.className='ql-img';
+    img.src=app.icon || `assets/apps/${app.id}/icon.png`;
+    btn.appendChild(img);
+    btn.onclick=(e)=>{ e.stopPropagation(); openAppWindow(app); };
+    quick.appendChild(btn);
+  }
 
-  const label = document.createElement('div');
-  label.className = 'label';
-  label.textContent = app.title || app.id;
+  function addIcon(desktop, app){
+    const iconEl = document.createElement('div');
+    iconEl.className = 'icon';
+    iconEl.dataset.id = app.id;
+    iconEl.style.left = (app.x||20)+'px';
+    iconEl.style.top  = (app.y||20)+'px';
 
-  iconEl.appendChild(imgWrap);
-  iconEl.appendChild(label);
+    const imgWrap = document.createElement('div');
+    imgWrap.className = 'icon-img';
+    const img = document.createElement('img');
+    img.className = 'desk-icon-img';
+    img.src = app.icon || `assets/apps/${app.id}/icon.png`;
+    imgWrap.appendChild(img);
 
-  iconEl.onclick = (e) => {
-    e.stopPropagation();
-    openAppWindow(app);
-  };
+    const label = document.createElement('div');
+    label.className = 'label';
+    label.textContent = app.title || app.id;
 
-  (document.getElementById('icons') || desktop).appendChild(iconEl);
-}
+    iconEl.appendChild(imgWrap);
+    iconEl.appendChild(label);
+
+    iconEl.onclick = (e) => {
+      e.stopPropagation();
+      openAppWindow(app);
+    };
+
+    let drag=false,sx=0,sy=0,ox=0,oy=0;
+    iconEl.addEventListener('mousedown',e=>{
+      if(e.button!==0) return;
+      drag=true; sx=e.clientX; sy=e.clientY;
+      const r=iconEl.getBoundingClientRect();
+      ox=r.left; oy=r.top; document.body.style.userSelect='none';
+      e.preventDefault();
+    });
+    window.addEventListener('mousemove',e=>{
+      if(!drag) return;
+      const dx=e.clientX-sx, dy=e.clientY-sy;
+      iconEl.style.left=(ox+dx)+'px';
+      iconEl.style.top =(oy+dy)+'px';
+    });
+    window.addEventListener('mouseup',()=>{
+      if(!drag) return;
+      drag=false; document.body.style.userSelect='';
+      const s=loadSettings();
+      s[app.id]=s[app.id]||{};
+      s[app.id].x=parseInt(iconEl.style.left)||0;
+      s[app.id].y=parseInt(iconEl.style.top)||0;
+      saveSettings(s);
+    });
+
+    (document.getElementById('icons') || desktop).appendChild(iconEl);
+  }
 
 
   async function buildDesktop(desktop, me){
+    const quick=document.getElementById('quick-launch');
+    if(quick) quick.innerHTML='';
+    const settings=loadSettings();
     let ids=[]; try{ ids=await getJSON('apps/apps.json'); }catch(e){ console.warn('apps.json failed',e); }
     if(!Array.isArray(ids)) ids=[];
+    const pinned=[];
+    let idx=0;
     for(const id of ids){
       try{
         const meta=await getJSON(`apps/${id}/app.json`);
-        addIcon(desktop,{ id, title:meta.title||id, icon:iconPath(id,meta.icon), x:meta.x,y:meta.y,w:meta.w,h:meta.h });
+        const s=settings[id]||{};
+        if(s.show===false) continue;
+        const posX = s.x ?? meta.x ?? (20 + (idx%5)*110);
+        const posY = s.y ?? meta.y ?? (20 + Math.floor(idx/5)*110);
+        addIcon(desktop,{ id, title:meta.title||id, icon:iconPath(id,meta.icon), x:posX, y:posY, w:meta.w, h:meta.h });
+        if(s.pinned) pinned.push({id,meta});
+        if(!settings[id]) settings[id]={};
+        if(settings[id].show===undefined) settings[id].show=true;
+        if(settings[id].x===undefined) settings[id].x=posX;
+        if(settings[id].y===undefined) settings[id].y=posY;
+        idx++;
       }catch(e){ console.warn(`app ${id} meta failed`,e); }
     }
+    const order=settings.pinnedOrder||[];
+    pinned.sort((a,b)=>{
+      const ai=order.indexOf(a.id); const bi=order.indexOf(b.id);
+      return (ai<0?Infinity:ai)-(bi<0?Infinity:bi);
+    });
+    for(const p of pinned){
+      addQuickIcon(quick,{ id:p.id, title:p.meta.title||p.id, icon:iconPath(p.id,p.meta.icon), w:p.meta.w, h:p.meta.h });
+    }
+    saveSettings(settings);
   }
+
+  window.refreshDesktop=async function(){
+    const {desktop}=ensureChrome();
+    if(desktop) desktop.innerHTML='<div id="icons"></div>';
+    await buildDesktop(desktop, window.currentUser||guest);
+  };
 
   function updateStatus(me){
     const el=document.getElementById('user-status');
+    const q=document.getElementById('quick-note-user');
     if(!el) return;
     const cap = s => s ? s.charAt(0).toUpperCase()+s.slice(1) : s;
     if(me && (me.username || me.id)){
       const id = me.id ?? me.username;
       const status = cap(me.status ?? me.tier);
       el.textContent = status ? `${id} (${status})` : `${id}`;
+      if(q) q.textContent=id;
     }else{
       el.textContent='Guest';
+      if(q) q.textContent='Guest';
     }
   }
 

--- a/system/startmenu/start.v1.js
+++ b/system/startmenu/start.v1.js
@@ -29,12 +29,13 @@
       });
     } else {
       const openAuth = (hash) => {
+        const h = window.innerHeight ? Math.max(300, window.innerHeight - 40) : 520;
         const inst = window.WM?.open({
           id: 'auth',
           title: 'Account',
           icon: 'assets/apps/auth/icon.png',
           url: `apps/auth/layout.html${hash}`,
-          w: 480, h: 520, x: 80, y: 80
+          w: 480, h, x: 80, y: 0
         });
         if (inst?.iframe) inst.iframe.src = `apps/auth/layout.html${hash}`;
       };


### PR DESCRIPTION
## Summary
- Batch show/pin changes in Customize app with Win95-style controls and reorder arrows
- Refresh desktop without full reload and honor saved pinned app order
- Make window content fill its container to remove inner scrollbars

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d96d7bfe08325b8154fe18282f01a