### PR TITLE
Refine desktop UI and customization behavior

### DIFF
--- a/apps/customize/layout.html
+++ b/apps/customize/layout.html
@@ -6,9 +6,9 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <style>
 
-    html,body{height:100%}
+    html,body{height:100%;overflow:hidden}
     body{margin:0;padding:10px;font:13px Tahoma,"MS Sans Serif",Arial,sans-serif;background:#fff;color:#000;display:flex;flex-direction:column}
-    #apps{flex:1;overflow:auto}
+    #apps{flex:1;overflow:auto;margin-bottom:8px}
     .row{display:flex;align-items:center;gap:8px;margin-bottom:4px}
     label{margin-right:10px}
     button{background:#c0c0c0;border:2px outset #fff;padding:2px 6px;cursor:pointer}
@@ -66,7 +66,7 @@
         });
         s.pinnedOrder=Array.from(listEl.children).map(r=>r.dataset.id);
         save(s);
-        window.top.refreshDesktop?.();
+        window.top.applyDesktopSettings?.();
         window.top.WM?.close('customize');
       };
       document.getElementById('cancel').onclick=()=>{window.top.WM?.close('customize');};

--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -111,36 +111,6 @@ body{
 .taskbtn.active{ border:2px inset var(--border-light); background:#ddd; }
 
 /* status now outside, above the bar */
-.status-outside{
-  position: absolute;
-  right: 10px;
-  bottom: calc(var(--taskbar-height) + var(--taskbar-band) + 6px);
-  color: #fff;
-  font-size: 12px;
-  text-shadow: 1px 1px 0 #000;
-  background: rgba(0,0,0,0.15);
-  padding: 2px 6px;
-  border-radius: 3px;
-}
-
-.quick-note{
-  position: absolute;
-  right: 10px;
-  bottom: calc(var(--taskbar-height) + var(--taskbar-band) + 40px);
-  display:flex;
-  flex-direction:column;
-  gap:4px;
-}
-.quick-note label{
-  color:#fff;
-  font-size:12px;
-  text-shadow:1px 1px 0 #000;
-}
-.quick-note input{
-  padding:4px;
-  width:200px;
-  box-sizing:border-box;
-}
 
 /* Clock inside bar, right */
 .clock{

--- a/index.html
+++ b/index.html
@@ -21,11 +21,6 @@
 
   <div id="start-menu" class="start-menu hidden"></div>
 
-  <div id="user-status" class="status-outside"></div>
-  <div id="quick-note" class="quick-note">
-    <label id="quick-note-user"></label>
-    <input id="quick-note-input" type="text" />
-  </div>
 
   <!-- ORDER MATTERS -->
   <script src="system/wm.v1.js"></script>

--- a/system/startmenu/start.v1.js
+++ b/system/startmenu/start.v1.js
@@ -29,7 +29,8 @@
       });
     } else {
       const openAuth = (hash) => {
-        const h = window.innerHeight ? Math.max(300, window.innerHeight - 40) : 520;
+        const h0 = window.innerHeight ? Math.max(300, window.innerHeight - 40) : 520;
+        const h = Math.max(150, Math.floor(h0/2));
         const inst = window.WM?.open({
           id: 'auth',
           title: 'Account',
@@ -50,7 +51,7 @@
         title: 'Customize',
         icon: 'assets/apps/profile/icon.png',
         url: 'apps/customize/layout.html',
-        w: 520, h: 420, x: 120, y: 110
+        w: 520, h: 520, x: 120, y: 110
       });
     });
     mkItem(menu, 'Bug Report', () => {


### PR DESCRIPTION
## Summary
- Remove guest status bar and quick note textbox from desktop UI and associated CSS.
- Resize login and customization windows for better layout; adjust customization app to avoid double scrolling.
- Apply customization changes in place without reloading desktop or taskbar.

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check system/loader.v1.js`
- `node --check system/startmenu/start.v1.js`


------
https://chatgpt.com/codex/tasks/task_e_689e0cbdf3748325b431c6e317ca0dca