### PR TITLE
Load desktop customization settings from server

### DIFF
--- a/apps/customize/layout.html
+++ b/apps/customize/layout.html
@@ -26,25 +26,21 @@
     <button id="cancel">Cancel</button>
   </div>
   <script>
-    const KEY='desktop_settings';
-    function load(){
-      if(window.top.currentUser?.username){
-        try{return JSON.parse(window.top.localStorage.getItem(KEY))||{};}catch{return{};}
-      }
-      return window.top._tempSettings||{};
+    async function load(){
+      try{return await window.top.getJSON('/api/settings');}catch{return{};}
     }
-    function save(s){
-      if(window.top.currentUser?.username){
-        try{window.top.localStorage.setItem(KEY, JSON.stringify(s));}catch{}
-      }else{
-        window.top._tempSettings=s;
-      }
+    async function save(s){
+      try{await window.top.putJSON('/api/settings', s);}catch{}
     }
 
     async function init(){
+      if(!window.top.currentUser?.username){
+        document.body.innerHTML='<p>Please log in to customize.</p>';
+        return;
+      }
       const listEl=document.getElementById('apps');
       const ids=await (await fetch('../apps.json')).json();
-      const settings=load();
+      const settings=await load();
 
       const order=(settings.pinnedOrder&&settings.pinnedOrder.filter(id=>ids.includes(id)))||ids.slice();
       ids.forEach(id=>{if(!order.includes(id)) order.push(id);});
@@ -69,8 +65,8 @@
           const next=row.nextElementSibling; if(next) listEl.insertBefore(next,row);
         }
       });
-      document.getElementById('save').onclick=()=>{
-        const s=load();
+      document.getElementById('save').onclick=async()=>{
+        const s=await load();
         Array.from(listEl.children).forEach(row=>{
           const id=row.dataset.id;
           s[id]=s[id]||{};
@@ -78,8 +74,8 @@
           s[id].pinned=row.querySelector('.pin').checked;
         });
         s.pinnedOrder=Array.from(listEl.children).map(r=>r.dataset.id);
-        save(s);
-        window.top.applyDesktopSettings?.();
+        await save(s);
+        await window.top.applyDesktopSettings?.();
         window.top.WM?.close('customize');
       };
       document.getElementById('cancel').onclick=()=>{window.top.WM?.close('customize');};

--- a/system/startmenu/start.v1.js
+++ b/system/startmenu/start.v1.js
@@ -44,16 +44,18 @@
       mkItem(menu, 'Create account', () => openAuth('#create'));
     }
 
-    // Always visible utilities (open if present)
-    mkItem(menu, 'Customize', () => {
-      window.WM?.open({
-        id: 'customize',
-        title: 'Customize',
-        icon: 'assets/apps/profile/icon.png',
-        url: 'apps/customize/layout.html',
-        w: 520, h: 520, x: 120, y: 110
+    // Utilities only for logged-in users
+    if (me.username) {
+      mkItem(menu, 'Customize', () => {
+        window.WM?.open({
+          id: 'customize',
+          title: 'Customize',
+          icon: 'assets/apps/profile/icon.png',
+          url: 'apps/customize/layout.html',
+          w: 520, h: 520, x: 120, y: 110
+        });
       });
-    });
+    }
     mkItem(menu, 'Bug Report', () => {
       window.WM?.open({
         id: 'bug',


### PR DESCRIPTION
## Summary
- Store per-user desktop customization on the server instead of localStorage
- Hide customization UI for guests and only expose via start menu when logged in
- Refresh desktop icons based on server settings including order, visibility, and pinning

## Testing
- `cd server && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689e11ee692c8325bdb9858cc7a3319a