### PR TITLE
Fix chat message posting and room listing

### DIFF
--- a/apps/chat/chat.js
+++ b/apps/chat/chat.js
@@ -50,26 +50,33 @@
 
   // ---- API adapters (Pi) ----
   async function apiListRooms(){
-    const r = await fetch(`${SITE().apiBase}/chat/rooms`, {cache:"no-cache"});
+    const r = await fetch(`${SITE().apiBase}/chat/rooms`, {cache:"no-cache", credentials:"include"});
     if (!r.ok) throw new Error("rooms "+r.status);
-    return r.json();
+    const data = await r.json();
+    return data.rooms || [];
   }
   async function apiCreateRoom(name){
     const r = await fetch(`${SITE().apiBase}/chat/rooms`, {
-      method:"POST", headers:{"Content-Type":"application/json"},
-      body: JSON.stringify({ name: sanitizeRoom(name) })
+      method:"POST",
+      headers:{"Content-Type":"application/json"},
+      credentials:"include",
+      body: JSON.stringify({ room: sanitizeRoom(name) })
     });
     if (!r.ok) throw new Error("create "+r.status);
-    return (await r.json())?.name || sanitizeRoom(name);
+    const data = await r.json();
+    return data?.room || sanitizeRoom(name);
   }
   async function apiGetMsgs(room){
-    const r = await fetch(`${SITE().apiBase}/chat/rooms/${encodeURIComponent(room)}`, {cache:"no-cache"});
+    const r = await fetch(`${SITE().apiBase}/chat/rooms/${encodeURIComponent(room)}`, {cache:"no-cache", credentials:"include"});
     if (!r.ok) throw new Error("msgs "+r.status);
     return r.json();
   }
   async function apiPostMsg(room, msg){
     const r = await fetch(`${SITE().apiBase}/chat/rooms/${encodeURIComponent(room)}`, {
-      method:"POST", headers:{"Content-Type":"application/json"}, body: JSON.stringify(msg)
+      method:"POST",
+      headers:{"Content-Type":"application/json"},
+      credentials:"include",
+      body: JSON.stringify({ text: msg.text })
     });
     if (!r.ok) throw new Error("post "+r.status);
   }

--- a/system/chat/chat.v1.js
+++ b/system/chat/chat.v1.js
@@ -45,10 +45,37 @@
   }
 
   // API backend
-  async function apiListRooms(){ const r = await fetch(`${SITE().apiBase}/chat/rooms`, {cache:"no-cache"}); if(!r.ok) throw new Error("rooms "+r.status); return r.json(); }
-  async function apiCreateRoom(name){ const r = await fetch(`${SITE().apiBase}/chat/rooms`, { method:"POST", headers:{"Content-Type":"application/json"}, body: JSON.stringify({ room: sanitizeRoom(name) }) }); if(!r.ok) throw new Error("create "+r.status); return (await r.json())?.room || sanitizeRoom(name); }
-  async function apiGetMsgs(room){ const r = await fetch(`${SITE().apiBase}/chat/rooms/${encodeURIComponent(room)}`, {cache:"no-cache"}); if(!r.ok) throw new Error("msgs "+r.status); return r.json(); }
-  async function apiPostMsg(room, msg){ const r = await fetch(`${SITE().apiBase}/chat/rooms/${encodeURIComponent(room)}`, { method:"POST", headers:{"Content-Type":"application/json"}, body: JSON.stringify(msg) }); if(!r.ok) throw new Error("post "+r.status); }
+  async function apiListRooms(){
+    const r = await fetch(`${SITE().apiBase}/chat/rooms`, {cache:"no-cache", credentials:"include"});
+    if(!r.ok) throw new Error("rooms "+r.status);
+    const data = await r.json();
+    return data.rooms || [];
+  }
+  async function apiCreateRoom(name){
+    const r = await fetch(`${SITE().apiBase}/chat/rooms`, {
+      method:"POST",
+      headers:{"Content-Type":"application/json"},
+      credentials:"include",
+      body: JSON.stringify({ room: sanitizeRoom(name) })
+    });
+    if(!r.ok) throw new Error("create "+r.status);
+    const data = await r.json();
+    return data?.room || sanitizeRoom(name);
+  }
+  async function apiGetMsgs(room){
+    const r = await fetch(`${SITE().apiBase}/chat/rooms/${encodeURIComponent(room)}`, {cache:"no-cache", credentials:"include"});
+    if(!r.ok) throw new Error("msgs "+r.status);
+    return r.json();
+  }
+  async function apiPostMsg(room, msg){
+    const r = await fetch(`${SITE().apiBase}/chat/rooms/${encodeURIComponent(room)}`, {
+      method:"POST",
+      headers:{"Content-Type":"application/json"},
+      credentials:"include",
+      body: JSON.stringify({ text: msg.text })
+    });
+    if(!r.ok) throw new Error("post "+r.status);
+  }
 
   const listRooms = () => useApi() ? apiListRooms() : lsListRooms();
   const createRoom = (n) => useApi() ? apiCreateRoom(n) : lsCreateRoom(n);


### PR DESCRIPTION
## Summary
- include credentials and extract room lists so chat rooms display and logged-in users can send messages
- post only message text to API to persist chats across sessions

## Testing
- `cd server && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689e0fdfd0ac8325853ba0fb02e07b11