### PR TITLE
Ensure desktop loads once and customization changes persist

### DIFF
--- a/apps/customize/layout.html
+++ b/apps/customize/layout.html
@@ -27,10 +27,10 @@
   </div>
   <script>
     async function load(){
-      try{return await window.top.getJSON('/api/settings');}catch{return{};}
+      try{return await window.top.loadSettings?.();}catch{return{};}
     }
     async function save(s){
-      try{await window.top.putJSON('/api/settings', s);}catch{}
+      try{await window.top.saveSettings?.(s);}catch{}
     }
 
     async function init(){
@@ -75,7 +75,7 @@
         });
         s.pinnedOrder=Array.from(listEl.children).map(r=>r.dataset.id);
         await save(s);
-        await window.top.applyDesktopSettings?.();
+        await window.top.refreshDesktop?.();
         window.top.WM?.close('customize');
       };
       document.getElementById('cancel').onclick=()=>{window.top.WM?.close('customize');};

--- a/system/loader.v1.js
+++ b/system/loader.v1.js
@@ -35,6 +35,9 @@
     try{ await putJSON(`${API}/settings`, s); }catch{}
   }
 
+  window.loadSettings = loadSettings;
+  window.saveSettings = saveSettings;
+
   function ensure(id,cls){let e=document.getElementById(id); if(!e){ e=document.createElement('div'); e.id=id; if(cls)e.className=cls; document.body.appendChild(e);} return e;}
   function ensureChrome(){
     const desktop=ensure('desktop','desktop');
@@ -229,7 +232,7 @@
   }
 
   const boot=async()=>{
-    const {desktop}=ensureChrome();
+    ensureChrome();
     let site={apiBase:'/api',devMode:false,wallpaper:'assets/wallpapers/frogs.jpg'};
     try{ site={...site,...(await getJSON('config/site.json'))}; }catch{}
     API=site.apiBase||'/api'; window.API=API; window.API_BASE=API; window.siteConfig=site;
@@ -239,9 +242,7 @@
     }catch{}
     let me=guest; window.currentUser=me;
     try{ me=await getJSON(`${API}/me`); window.currentUser=me; }catch{}
-    updateStatus(me);
     if(me.tier==='devmode'){ getJSON(`${API}/admin/settings`).then(s=>window.siteAdmin=s).catch(()=>{}); }
-    await buildDesktop(desktop, me);
     startClock();
     try{ window.dispatchEvent(new CustomEvent('auth:me',{detail:me})); }catch{}
   };


### PR DESCRIPTION
## Summary
- Expose settings helpers and streamline boot sequence to avoid double desktop build
- Use shared settings helpers in customize app and reload desktop after saving

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e1822cb5483258f3ffdf9c2d6f235