### PR TITLE
Ensure desktop loads once and customization changes persist

### DIFF
--- a/apps/customize/layout.html
+++ b/apps/customize/layout.html
@@ -8,29 +8,28 @@
 
     html,body{height:100%;overflow:hidden}
     body{margin:0;padding:10px;font:13px Tahoma,"MS Sans Serif",Arial,sans-serif;background:#fff;color:#000;display:flex;flex-direction:column}
-    #apps{flex:1;overflow:auto;margin-bottom:8px}
+    #apps{flex:1;overflow:auto}
     .row{display:flex;align-items:center;gap:8px;margin-bottom:4px}
     .name{min-width:80px}
     label{margin-right:10px}
     button{background:#c0c0c0;border:2px outset #fff;padding:2px 6px;cursor:pointer}
     button:active{border:2px inset #fff}
-    .buttons{display:flex;gap:8px;margin-top:8px}
+    .buttons{display:flex;gap:8px;margin-top:8px;flex-shrink:0}
 
   </style>
 </head>
 <body>
-  <div id="apps"></div>
+  <div id="apps">Loading...</div>
 
-  <div class="buttons">
-    <button id="save">Save</button>
-    <button id="cancel">Cancel</button>
-  </div>
+    <div class="buttons">
+      <button id="save">Save</button>
+    </div>
   <script>
     async function load(){
-      try{return await window.top.getJSON('/api/settings');}catch{return{};}
+      try{return await window.top.loadSettings?.();}catch{return{};}
     }
     async function save(s){
-      try{await window.top.putJSON('/api/settings', s);}catch{}
+      try{await window.top.saveSettings?.(s);}catch{}
     }
 
     async function init(){
@@ -39,11 +38,14 @@
         return;
       }
       const listEl=document.getElementById('apps');
-      const ids=await (await fetch('../apps.json')).json();
+      let ids=[];
+      try{ ids=await (await fetch('../apps.json')).json(); }
+      catch{ listEl.textContent='Failed to load apps.'; return; }
       const settings=await load();
 
       const order=(settings.pinnedOrder&&settings.pinnedOrder.filter(id=>ids.includes(id)))||ids.slice();
       ids.forEach(id=>{if(!order.includes(id)) order.push(id);});
+      listEl.textContent='';
       order.forEach(id=>{
         const s=settings[id]||{};
         const row=document.createElement('div');
@@ -75,13 +77,18 @@
         });
         s.pinnedOrder=Array.from(listEl.children).map(r=>r.dataset.id);
         await save(s);
-        await window.top.applyDesktopSettings?.();
+        await window.top.refreshDesktop?.();
         window.top.WM?.close('customize');
       };
-      document.getElementById('cancel').onclick=()=>{window.top.WM?.close('customize');};
 
+      if(!listEl.children.length){
+        listEl.textContent='No apps available.';
+      }
     }
-    init();
+    init().catch(()=>{
+      const listEl=document.getElementById('apps');
+      listEl.textContent='Failed to load customization.';
+    });
   </script>
 </body>
 </html>

--- a/system/loader.v1.js
+++ b/system/loader.v1.js
@@ -35,6 +35,9 @@
     try{ await putJSON(`${API}/settings`, s); }catch{}
   }
 
+  window.loadSettings = loadSettings;
+  window.saveSettings = saveSettings;
+
   function ensure(id,cls){let e=document.getElementById(id); if(!e){ e=document.createElement('div'); e.id=id; if(cls)e.className=cls; document.body.appendChild(e);} return e;}
   function ensureChrome(){
     const desktop=ensure('desktop','desktop');
@@ -229,7 +232,7 @@
   }
 
   const boot=async()=>{
-    const {desktop}=ensureChrome();
+    ensureChrome();
     let site={apiBase:'/api',devMode:false,wallpaper:'assets/wallpapers/frogs.jpg'};
     try{ site={...site,...(await getJSON('config/site.json'))}; }catch{}
     API=site.apiBase||'/api'; window.API=API; window.API_BASE=API; window.siteConfig=site;
@@ -239,9 +242,7 @@
     }catch{}
     let me=guest; window.currentUser=me;
     try{ me=await getJSON(`${API}/me`); window.currentUser=me; }catch{}
-    updateStatus(me);
     if(me.tier==='devmode'){ getJSON(`${API}/admin/settings`).then(s=>window.siteAdmin=s).catch(()=>{}); }
-    await buildDesktop(desktop, me);
     startClock();
     try{ window.dispatchEvent(new CustomEvent('auth:me',{detail:me})); }catch{}
   };

--- a/system/startmenu/start.v1.js
+++ b/system/startmenu/start.v1.js
@@ -52,7 +52,7 @@
           title: 'Customize',
           icon: 'assets/apps/profile/icon.png',
           url: 'apps/customize/layout.html',
-          w: 520, h: 520, x: 120, y: 110
+          w: 520, h: 560, x: 120, y: 110
         });
       });
     }


### PR DESCRIPTION
## Summary
- Expose settings helpers and streamline boot sequence to avoid double desktop build
- Use shared settings helpers in customize app and reload desktop after saving
- Handle missing app list, drop cancel button, and enlarge customize window
- Prevent blank Customize window and keep Save button fully visible

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e1822cb5483258f3ffdf9c2d6f235