### PR TITLE
Disable caching for chat room messages

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -211,6 +211,7 @@ app.get('/api/chat/rooms/:room', async (req, res) => {
   const fp = path.join(CHAT_DIR, `${room}.txt`);
   const msgs = await readJson(fp, []);
   const limit = Math.max(0, Math.min(500, Number(req.query.limit || 200)));
+  res.set('Cache-Control', 'no-store');
   res.json(msgs.slice(-limit));
 });
 


### PR DESCRIPTION
## Summary
- prevent caching of chat room history by setting `Cache-Control: no-store` on `/api/chat/rooms/:room` responses

## Testing
- `cd server && npm test`
- `node server.js` and `curl -i http://127.0.0.1:3000/api/chat/rooms/public`

------
https://chatgpt.com/codex/tasks/task_e_689e2aa32ce08325b9e359ec7d2a876f