### PR TITLE
Disable chat message caching

### DIFF
--- a/system/chat/chat.v1.js
+++ b/system/chat/chat.v1.js
@@ -64,7 +64,7 @@
     return data?.room || sanitizeRoom(name);
   }
   async function apiGetMsgs(room){
-    const r = await fetch(`${SITE().apiBase}/chat/rooms/${encodeURIComponent(room)}`, {cache:"no-cache", credentials:"include"});
+    const r = await fetch(`${SITE().apiBase}/chat/rooms/${encodeURIComponent(room)}?t=${Date.now()}`, {cache:"no-store", credentials:"include"});
     if(!r.ok) throw new Error("msgs "+r.status);
     return r.json();
   }


### PR DESCRIPTION
## Summary
- Ensure chat API requests bypass caches by appending a timestamp query parameter and using the `no-store` fetch cache policy.

## Testing
- `npm test` (from server directory)
- Manual verification: started API server, posted a message, and confirmed a subsequent fetch with a timestamp returned the new message.


------
https://chatgpt.com/codex/tasks/task_e_689e2aade7bc83259a01f33e9af7171d