### PR TITLE
Update site root path to /home/lavaa/iadorefrogs-site

### DIFF
--- a/server/frogs-api.service
+++ b/server/frogs-api.service
@@ -6,7 +6,7 @@ After=network.target
 Type=simple
 User=www-data
 Group=www-data
-Environment=SITE_ROOT=/var/www/html
+Environment=SITE_ROOT=/home/lavaa/iadorefrogs-site
 Environment=PORT=3000
 Environment=SESSION_SECRET=CHANGE_ME
 WorkingDirectory=/opt/frogs-api

--- a/server/install.sh
+++ b/server/install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SITE_ROOT="/var/www/html"
+SITE_ROOT="/home/lavaa/iadorefrogs-site"
 API_DIR="/opt/frogs-api"
 NGX_SITE="/etc/nginx/sites-available/iadorefrogs"
 SERVICE="/etc/systemd/system/frogs-api.service"

--- a/server/nginx-site.conf
+++ b/server/nginx-site.conf
@@ -2,7 +2,7 @@ server {
   listen 80;
   server_name iadorefrogs.com www.iadorefrogs.com;
 
-  root /var/www/html;
+  root /home/lavaa/iadorefrogs-site;
   index index.html;
 
   location / {

--- a/server/server.js
+++ b/server/server.js
@@ -5,7 +5,7 @@ const fs = require('fs/promises');
 const fssync = require('fs');
 const path = require('path');
 
-const SITE_ROOT = process.env.SITE_ROOT || '/var/www/html';
+const SITE_ROOT = process.env.SITE_ROOT || '/home/lavaa/iadorefrogs-site';
 const PORT = Number(process.env.PORT || 3000);
 const SESSION_SECRET = process.env.SESSION_SECRET || 'dev-secret';
 const NODE_ENV = process.env.NODE_ENV || 'production';


### PR DESCRIPTION
## Summary
- Update default `SITE_ROOT` to `/home/lavaa/iadorefrogs-site`
- Adjust systemd service and nginx config to serve from new location
- Refresh install script for new site root

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689e3e9813b4832583c1b321d2cb4feb